### PR TITLE
processor: consumer health — crash on terminal error, liveness state, HealthzHandler

### DIFF
--- a/processor/health.go
+++ b/processor/health.go
@@ -1,0 +1,43 @@
+package processor
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/nats-io/nats.go"
+)
+
+// ConnChecker is the subset of *nats.Conn needed by health checks.
+type ConnChecker interface {
+	IsClosed() bool
+	IsDraining() bool
+}
+
+var _ ConnChecker = (*nats.Conn)(nil)
+
+// HealthzHandler returns an HTTP handler suitable for a Kubernetes
+// liveness probe. It reports 503 when the NATS connection is
+// permanently closed or draining, or when any processor's fetch loop
+// has exited — states a restart can recover from. A temporarily
+// disconnected (reconnecting) connection is still considered healthy,
+// since the client recovers on its own and a restart would not help.
+func HealthzHandler(nc ConnChecker, procs ...*Processor) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if nc == nil || nc.IsClosed() {
+			http.Error(w, "nats connection closed", http.StatusServiceUnavailable)
+			return
+		}
+		if nc.IsDraining() {
+			http.Error(w, "nats connection draining", http.StatusServiceUnavailable)
+			return
+		}
+		for i, p := range procs {
+			if p.Stopped() {
+				http.Error(w, fmt.Sprintf("processor %d stopped", i), http.StatusServiceUnavailable)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(http.StatusText(http.StatusOK)))
+	}
+}

--- a/processor/health_test.go
+++ b/processor/health_test.go
@@ -58,6 +58,21 @@ func TestLastActivityUpdatedOnEachFetchIteration(t *testing.T) {
 	}
 }
 
+func TestProcessExitsProcessOnTerminalError(t *testing.T) {
+	exitCode := -1
+	origExit := osExit
+	osExit = func(code int) { exitCode = code }
+	defer func() { osExit = origExit }()
+
+	c := &stubConsumer{next: func() (jetstream.Msg, error) { return nil, nats.ErrConnectionClosed }}
+	p := NewProcessor(c, func(m jetstream.Msg) error { return nil })
+	p.Process()
+
+	if exitCode != 1 {
+		t.Fatalf("Process() must exit with code 1 on terminal error, got %d", exitCode)
+	}
+}
+
 func TestStoppedFlagSetWhenRunReturns(t *testing.T) {
 	c := &stubConsumer{next: func() (jetstream.Msg, error) { return nil, nats.ErrConnectionClosed }}
 	p := NewProcessor(c, func(m jetstream.Msg) error { return nil })

--- a/processor/health_test.go
+++ b/processor/health_test.go
@@ -2,6 +2,8 @@ package processor
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -55,6 +57,47 @@ func TestLastActivityUpdatedOnEachFetchIteration(t *testing.T) {
 
 	if p.LastActivity().Before(start) {
 		t.Fatalf("LastActivity() = %v, must be at or after Run start %v", p.LastActivity(), start)
+	}
+}
+
+type stubConn struct{ closed, draining bool }
+
+func (s stubConn) IsClosed() bool   { return s.closed }
+func (s stubConn) IsDraining() bool { return s.draining }
+
+// stoppedProcessor returns a Processor whose Run loop has already exited.
+func stoppedProcessor() *Processor {
+	c := &stubConsumer{next: func() (jetstream.Msg, error) { return nil, nats.ErrConnectionClosed }}
+	p := NewProcessor(c, func(m jetstream.Msg) error { return nil })
+	p.Run()
+	return p
+}
+
+func TestHealthzHandler(t *testing.T) {
+	running := NewProcessor(&stubConsumer{}, func(m jetstream.Msg) error { return nil })
+
+	cases := []struct {
+		name string
+		nc   ConnChecker
+		proc *Processor
+		want int
+	}{
+		{"healthy", stubConn{}, running, http.StatusOK},
+		{"connection closed", stubConn{closed: true}, running, http.StatusServiceUnavailable},
+		{"connection draining", stubConn{draining: true}, running, http.StatusServiceUnavailable},
+		{"processor stopped", stubConn{}, stoppedProcessor(), http.StatusServiceUnavailable},
+		{"nil connection", nil, running, http.StatusServiceUnavailable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			HealthzHandler(tc.nc, tc.proc)(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body: %q)", rec.Code, tc.want, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/processor/health_test.go
+++ b/processor/health_test.go
@@ -1,0 +1,76 @@
+package processor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// stubConsumer implements jetstream.Consumer for tests; only Next is used by Processor.
+type stubConsumer struct {
+	next func() (jetstream.Msg, error)
+}
+
+func (s *stubConsumer) Next(opts ...jetstream.FetchOpt) (jetstream.Msg, error) { return s.next() }
+func (s *stubConsumer) Fetch(batch int, opts ...jetstream.FetchOpt) (jetstream.MessageBatch, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) FetchBytes(maxBytes int, opts ...jetstream.FetchOpt) (jetstream.MessageBatch, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) FetchNoWait(batch int) (jetstream.MessageBatch, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) Consume(handler jetstream.MessageHandler, opts ...jetstream.PullConsumeOpt) (jetstream.ConsumeContext, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) Messages(opts ...jetstream.PullMessagesOpt) (jetstream.MessagesContext, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) Info(ctx context.Context) (*jetstream.ConsumerInfo, error) {
+	panic("not implemented")
+}
+func (s *stubConsumer) CachedInfo() *jetstream.ConsumerInfo { panic("not implemented") }
+
+func TestLastActivityUpdatedOnEachFetchIteration(t *testing.T) {
+	calls := 0
+	c := &stubConsumer{next: func() (jetstream.Msg, error) {
+		calls++
+		if calls < 3 {
+			return nil, nats.ErrTimeout // non-terminal: loop continues
+		}
+		return nil, nats.ErrConnectionClosed
+	}}
+	p := NewProcessor(c, func(m jetstream.Msg) error { return nil })
+
+	if !p.LastActivity().IsZero() {
+		t.Fatal("LastActivity() must be zero before Run")
+	}
+
+	start := time.Now()
+	p.Run()
+
+	if p.LastActivity().Before(start) {
+		t.Fatalf("LastActivity() = %v, must be at or after Run start %v", p.LastActivity(), start)
+	}
+}
+
+func TestStoppedFlagSetWhenRunReturns(t *testing.T) {
+	c := &stubConsumer{next: func() (jetstream.Msg, error) { return nil, nats.ErrConnectionClosed }}
+	p := NewProcessor(c, func(m jetstream.Msg) error { return nil })
+
+	if p.Stopped() {
+		t.Fatal("Stopped() must be false before Run")
+	}
+
+	err := p.Run()
+	if err == nil {
+		t.Fatal("Run must return the terminal fetch error")
+	}
+	if !p.Stopped() {
+		t.Fatal("Stopped() must be true after Run returns")
+	}
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"errors"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -45,6 +46,27 @@ type Processor struct {
 	processFn    ProcessFn
 	fetchTimeout time.Duration
 	conditionFn  ConditionCheckFn
+	stopped      atomic.Bool
+	lastActivity atomic.Int64 // unix nanoseconds of the last fetch loop iteration
+}
+
+// Stopped reports whether the processing loop has exited.
+// A stopped processor no longer consumes messages and the owning
+// process should be considered unhealthy.
+func (p *Processor) Stopped() bool {
+	return p.stopped.Load()
+}
+
+// LastActivity returns the time of the last fetch loop iteration,
+// or the zero time if the loop has not started. The loop iterates at
+// least once per fetch timeout, so a value much older than the fetch
+// timeout indicates a stuck processor.
+func (p *Processor) LastActivity() time.Time {
+	ns := p.lastActivity.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
 }
 
 // WithFetchTimeout sets the timeout duration for fetching messages.
@@ -86,9 +108,11 @@ func (p *Processor) Process() {
 }
 
 func (p *Processor) Run() error {
+	defer p.stopped.Store(true)
 	slog.Info("Looping...")
 	// Continuously attempt to fetch and process messages.
 	for {
+		p.lastActivity.Store(time.Now().UnixNano())
 		// Attempt to fetch the next message with a maximum wait time.
 		msg, err := p.consumer.Next(jetstream.FetchMaxWait(p.fetchTimeout))
 		if err != nil {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"errors"
 	"log/slog"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -11,6 +12,9 @@ import (
 )
 
 const defaultFetchTimeout = 60 * time.Second
+
+// osExit is replaceable in tests.
+var osExit = os.Exit
 
 // ConditionResult represents the result of a condition check
 type ConditionResult struct {
@@ -101,9 +105,14 @@ func NewProcessor(consumer jetstream.Consumer, processFn ProcessFn, opts ...func
 	return p
 }
 
+// Process runs the fetch loop and exits the process if the loop stops
+// on a terminal error. Exiting lets the platform (e.g. Kubernetes)
+// restart the consumer instead of leaving a process that looks healthy
+// but no longer consumes messages.
 func (p *Processor) Process() {
 	if err := p.Run(); err != nil {
-		slog.Error("Processor stopped", "err", err)
+		slog.Error("Processor stopped on terminal error, exiting", "err", err)
+		osExit(1)
 	}
 }
 


### PR DESCRIPTION
## Problem

When a processor's fetch loop dies (e.g. `nats.ErrConnectionClosed` after reconnect attempts are exhausted, or `ErrConsumerDeleted`), `Process()` only logged the error. The owning process kept serving HTTP, its unconditional `/healthz` endpoints kept returning 200, and Kubernetes saw a green pod — while the consumer silently processed nothing until someone manually restarted it.

## Changes

- **`Processor.Stopped()` / `Processor.LastActivity()`** — atomic loop-liveness state: `Stopped()` flips when `Run()` returns; `LastActivity()` is the timestamp of the last fetch-loop iteration (updated at least once per fetch timeout). `Run()`'s signature is unchanged, so existing callers compile as-is.
- **`Process()` exits the process (code 1) on terminal error** — crash-only behavior lets Kubernetes restart the consumer even if a service never wires the new probe handler, and turns a prolonged NATS outage into visible CrashLoopBackOff instead of silent green pods.
- **`HealthzHandler(nc, procs...)`** — liveness-probe handler returning 503 when the connection is closed/draining or any processor has stopped. A *reconnecting* connection still reports healthy: with `MaxReconnects(-1)` the client recovers on its own, and restarting during a NATS blip would cause a restart storm. Takes a small `ConnChecker` interface (satisfied by `*nats.Conn`, compile-time asserted).

`LastActivity()` deliberately does not gate the handler — some `processFn`s legitimately run for minutes, and a staleness gate would risk false restarts mid-message. It's exposed for services that want their own threshold.

## Usage (per service, ~2 lines)

```go
s.R.Get("/healthz", processor.HealthzHandler(nc, proc)) // liveness
```

## Testing

Written test-first; all behaviors covered in `processor/health_test.go` with a stubbed `jetstream.Consumer`. `go test -race ./processor/` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)